### PR TITLE
fix: prevent iCloud access when using local mode

### DIFF
--- a/telekom-data-usage.js
+++ b/telekom-data-usage.js
@@ -114,7 +114,9 @@ async function saveImages() {
 
 async function getImageFor(name) {
   let img_path = fm.joinPath(dir, name + ".png");
-  await fm.downloadFileFromiCloud(img_path);
+  if (parameters.includes("icloud")) {
+    await fm.downloadFileFromiCloud(img_path);
+  }
   img = await fm.readImage(img_path);
   return img;
 }
@@ -126,7 +128,9 @@ async function saveData(data) {
 }
 
 async function getFromFile() {
-  await fm.downloadFileFromiCloud(path);
+  if (parameters.includes("icloud")) {
+    await fm.downloadFileFromiCloud(path);
+  }
   data = await JSON.parse(fm.readString(path));
   console.log("Fetching data from file was successful");
   return data;


### PR DESCRIPTION
In local mode, a local FileManager is used. In this case, calling downloadFileFromiCloud() will result in an API error.

Add a check if icloud parameter is set before calling downloadFileFromiCloud().